### PR TITLE
Fix Authorization header

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -284,7 +284,7 @@ export class Request {
       xhr.setRequestHeader('Accept', 'application/json')
     }
 
-    if(this.auth === 'string') {
+    if(this.auth && typeof this.auth === 'string') {
       xhr.setRequestHeader('Authorization', this.auth);
     }
 

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -25,6 +25,19 @@ test('failure retries, then rejects promise', (t : any) => {
   let request = requests.queue[0]
 })
 
+test('authorization header', (t : any) => {
+  t.plan(1)
+  const requests = new RequestQueue()
+  requests.get(`${TEST_URL}/headers`, {
+    auth: 'Test auth',
+    responseType: 'json'
+  }).then((response) => {
+    t.equal(response.headers.Authorization, 'Test auth')
+  }).catch(() => {
+    t.fail('Request failed')
+  })
+})
+
 test('arraybuffer responseType', (t : any) => {
   t.plan(2)
   const requests = new RequestQueue()


### PR DESCRIPTION
The current implementation of the Authorization header checks for the value 'string', instead of checking type