### PR TITLE
Optional progress callback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,12 +10,12 @@ export enum RequestStatus {
 
 export interface Options {
   priority?: RequestPriority;
-  responseType?: any;
-  body?: any;
+  responseType?: string;
+  body?: string;
   maxRetries?: number;
-  auth?: any;
+  auth?: string;
   headers?: { [key: string]: any };
-  onProgress?: (evt: any) => void;
+  onProgress?: (evt: ProgressEvent) => void;
 }
 
 /**
@@ -249,10 +249,10 @@ export class Request {
   constructor(method: string, url: string, options: Options = {}) {
     this.url = url
     this.method = method
-    this.auth = options.auth
+    this.auth = options.auth || null
     this.priority = <number> options.priority
-    this.responseType = options.responseType
-    this.body = options.body
+    this.responseType = options.responseType || null
+    this.body = options.body || null
     this.headers = options.headers
     this.maxRetries = options.maxRetries || null
     this.onProgress = options.onProgress;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,16 @@ export enum RequestStatus {
   PENDING, SENDING, FAILED, DONE
 }
 
+export interface Options {
+  priority?: RequestPriority;
+  responseType?: any;
+  body?: any;
+  maxRetries?: number;
+  auth?: any;
+  headers?: { [key: string]: any };
+  onProgress?: (evt: any) => void;
+}
+
 /**
  * Utility: Cross-browser XHR request,
  * Only here to support IE <= 7...
@@ -218,6 +228,7 @@ export class Request {
   promise: Promise<any>
   onDone: Function
   onFail: Function
+  onProgress?: (evt: any) => void;
 
   private xhr: XMLHttpRequest | null
 
@@ -235,22 +246,16 @@ export class Request {
    *       headers = {}
    *     }
    */
-  constructor(method: string, url: string, {
-    priority = RequestPriority.MEDIUM,
-    responseType = null,
-    body = null,
-    maxRetries = null,
-    auth = null,
-    headers = {},
-    } = {}) {
+  constructor(method: string, url: string, options: Options = {}) {
     this.url = url
     this.method = method
-    this.auth = auth
-    this.priority = priority
-    this.responseType = responseType
-    this.body = body
-    this.headers = headers
-    this.maxRetries = maxRetries
+    this.auth = options.auth
+    this.priority = <number> options.priority
+    this.responseType = options.responseType
+    this.body = options.body
+    this.headers = options.headers
+    this.maxRetries = options.maxRetries || null
+    this.onProgress = options.onProgress;
     this.promise = new Promise((resolve, reject) => {
       this.onDone = resolve
       this.onFail = reject
@@ -295,6 +300,10 @@ export class Request {
     if (this.body && typeof this.body === 'object') {
       this.body = JSON.stringify(this.body)
       xhr.setRequestHeader('Content-Type', 'application/json')
+    }
+
+    if (this.onProgress) {
+      xhr.onprogress = this.onProgress;
     }
 
     return new Promise((resolve, reject) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -250,7 +250,7 @@ export class Request {
     this.url = url
     this.method = method
     this.auth = options.auth || null
-    this.priority = <number> options.priority
+    this.priority = options.priority || RequestPriority.MEDIUM
     this.responseType = options.responseType || null
     this.body = options.body || null
     this.headers = options.headers || {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,7 +220,7 @@ export class Request {
   responseType: string | null
   auth: string | null
   body: string | null
-  headers: any
+  headers: { [key: string]: any }
 
   sendAttempts = 0
   status = RequestStatus.PENDING
@@ -228,7 +228,7 @@ export class Request {
   promise: Promise<any>
   onDone: Function
   onFail: Function
-  onProgress?: (evt: any) => void;
+  onProgress?: (evt: ProgressEvent) => void;
 
   private xhr: XMLHttpRequest | null
 
@@ -253,7 +253,7 @@ export class Request {
     this.priority = <number> options.priority
     this.responseType = options.responseType || null
     this.body = options.body || null
-    this.headers = options.headers
+    this.headers = options.headers || {}
     this.maxRetries = options.maxRetries || null
     this.onProgress = options.onProgress;
     this.promise = new Promise((resolve, reject) => {


### PR DESCRIPTION
Most important change is the addition of this, optional support for a progress callback to receive `ProgressEvent`s.:
```
if (this.onProgress) {
  xhr.onprogress = this.onProgress;
}
```

The rest of the PR is mostly just switching up some typings.